### PR TITLE
74147-MakeImageIndependentFromICMBaseImage

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/icm/docker/ICMDockerPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/ICMDockerPlugin.kt
@@ -201,14 +201,14 @@ open class ICMDockerPlugin : Plugin<Project> {
         with(extension) {
             val mainImages = calculateImageTag(project, imageBuild, imageBuild.images.mainImage)
             val imgTask = createImageTask(
-                    project, images.icmsetup, imageBuild, imageBuild.images.mainImage, mainImages, BUILD_MAIN_IMAGE)
+                    project, imageBuild, imageBuild.images.mainImage, mainImages, BUILD_MAIN_IMAGE)
 
             imgTask.configure { task ->
                 task.description = "Creates the main image with an appserver."
             }
             val testImages = calculateImageTag(project, imageBuild, imageBuild.images.testImage)
             val testImgTask = createImageTask(
-                    project, images.icmsetup, imageBuild, imageBuild.images.testImage, testImages, BUILD_TEST_IMAGE)
+                    project, imageBuild, imageBuild.images.testImage, testImages, BUILD_TEST_IMAGE)
 
             testImgTask.configure { task ->
                 task.description = "Creates the test image of an appserver."
@@ -241,7 +241,6 @@ open class ICMDockerPlugin : Plugin<Project> {
 
     private fun createImageTask(
             project: Project,
-            setupImg: Property<String>,
             imgBuild: ProjectConfiguration,
             imgConf: ImageConfiguration,
             images: Provider<List<String>>,
@@ -262,7 +261,6 @@ open class ICMDockerPlugin : Plugin<Project> {
                         "${imgBuild.baseDescription.get()} - ${imgConf.description.get()}"
                     })
                 }
-                buildImage.buildArgs.put("SETUP_IMAGE", setupImg)
                 buildImage.images.set(images)
             }
 

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/extension/Images.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/extension/Images.kt
@@ -25,8 +25,6 @@ import javax.inject.Inject
  */
 open class Images @Inject constructor(objectFactory: ObjectFactory) {
 
-    val icmsetup: Property<String> = objectFactory.property(String::class.java)
-
     val webadapter: Property<String> = objectFactory.property(String::class.java)
 
     val webadapteragent: Property<String> = objectFactory.property(String::class.java)
@@ -58,7 +56,6 @@ open class Images @Inject constructor(objectFactory: ObjectFactory) {
         icmbasetest.convention("docker.intershop.de/intershop/icm-as-test:latest")
         icmcustomizationbase.convention("intershophub/icm-as-customization-base:latest")
 
-        icmsetup.convention("intershophub/icm-base:8.282.3")
         webadapter.convention("intershophub/icm-webadapter:2.1.0")
         webadapteragent.convention("intershophub/icm-webadapteragent:3.1.0")
 

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/utils/appserver/AbstractTaskPreparer.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/utils/appserver/AbstractTaskPreparer.kt
@@ -111,8 +111,6 @@ abstract class AbstractTaskPreparer(
                         to "/intershop/customizations/${extension.containerPrefix}/cartridges",
                 getOutputPathFor(TASK_CREATECLUSTERID, "")
                         to "/intershop/clusterid",
-                /* TODO remove File(extension.developmentConfig.configDirectory).absolutePath
-                        to "/intershop/conf",*/
         )
 
         if(customization) {


### PR DESCRIPTION
feat: make icm-as and icm-as-test images independent from icm-base image (#74147, #75489)

* removed com.intershop.gradle.icm.docker.extension.Images#icmsetup
* image creation is now done without build arg SETUP_IMAGE