### PR TITLE
85219 nginx proxy

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -210,6 +210,7 @@ imageBuild {
 |`mailsrv`  | `Property<String>` | `mailhog/mailhog:latest`       | A mail server for testing the mail feature of the application.
 |`solr`   | `Property<String>`      | `solr/latest`       | This image is used for the Solr Cloud configuration with a single node.
 |`zookeeper`   | `Property<String>` | `zookeeper:latest`  | This image is used for the Solr Cloud configuration with a single node.
+|`icm-nginx`   | `Property<String>` | `icm-nginx:latest`  | This image is used for the Nginx reverse proxy for development without the WebAdapter.
 |===
 
 ===== Image Build Configuration `ProjectConfiguration`[[ProjectConfiguration]]
@@ -287,7 +288,7 @@ For all properties configurations methods with a closure or an action are availa
 | *showICMASConfig*  | Shows a special part of icm.properties for local application server development.
 | *startEnv*         | Starts a docker based environment based on "intershop.environment.container" in the icm properties file.
 | *stopEnv*          | Stops the docker based environment based on "intershop.environment.container" in the icm properties file.
-
+| **NGINX* | These tasks pull, start, stop and remove the ICM NGINX image. This image contains a NGINX configured to terminate TLS and reverse proxy directly to the Application Server.
 |===
 
 ==== *generateICMProps* Parameters
@@ -370,6 +371,18 @@ The following properties are part of the <<PropertiesFile>>.
 | `intershop.ws.readinessProbe.interval` | interval in seconds to be used to check if the WebAdapter is ready | Integer | Optional | `2` +
 | `intershop.ws.readinessProbe.timeout` | max. number of seconds to wait for the WebAdapter to become ready | Integer | Optional | `30` +
 | `webserver.use.http2` | enables/disables usage of HTTP2 | Boolean | Optional | `false` +
+|===
+
+===== NGINX [[NGINXConfiguration]]
+[cols="10%,60%,10%,10%,10%", width="99%, options="header"]
+|===
+| Key | Description | Co-domain | Mandatory/Optional | Default value
+
+| `nginx.http.port` | the host port to be used for the NGINX http port | Integer | Optional | `8080` +
+| `nginx.https.port` | the host port to be used for the WebAdapter https port | Integer | Optional | `8443` +
+| `nginx.cert.path` | the host path to look for TLS certificate and private key (if not defined the certificates will be mounted from the Webserver certificate path) | Path | Optional | <none> +
+| `nginx.cert.filename` | name of the certificate file | String | Optional | `fullchain.pem` +
+| `nginx.privatekey.filename` | name of the certificate private key file | String | Optional | `privkey.pem` +
 |===
 
 ===== Solr [[SolrConfiguration]]

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/ICMDockerPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/ICMDockerPlugin.kt
@@ -43,6 +43,7 @@ import com.intershop.gradle.icm.docker.utils.solrcloud.TaskPreparer as SolrCloud
 import com.intershop.gradle.icm.docker.utils.solrcloud.TaskPreparer as SolrTaskPreparer
 import com.intershop.gradle.icm.docker.utils.webserver.TaskPreparer as WebServerPreparer
 import com.intershop.gradle.icm.docker.utils.webserver.TaskPreparer as WebTaskPreparer
+import com.intershop.gradle.icm.docker.utils.nginx.TaskPreparer as NginxTaskPreparer
 
 /**
  * Main plugin class of the project plugin.
@@ -83,9 +84,7 @@ open class ICMDockerPlugin : Plugin<Project> {
             val solrcloudPreparer = SolrCloudPreparer(project, networkTasks)
 
             val webServerTasks = WebServerPreparer(project, networkTasks)
-            /* TODO #72088
             val nginxTasks = NginxTaskPreparer(project, networkTasks.createNetworkTask, webServerTasks.waTasks)
-             */
 
             try {
                 tasks.named("dbPrepare").configure {
@@ -104,6 +103,7 @@ open class ICMDockerPlugin : Plugin<Project> {
                         mssqlTasks.removeTask,
                         mailSrvTask.removeTask,
                         webServerTasks.removeTask,
+                        nginxTasks.removeTask,
                         oracleTasks.removeTask,
                         solrcloudPreparer.removeTask)
             }
@@ -154,9 +154,9 @@ open class ICMDockerPlugin : Plugin<Project> {
             if (list.contains("oracle")) {
                 task.dependsOn("start${OracleTaskPreparer.extName}")
             }
-            /* TODO #72088 if (list.contains("nginx")) {
+            if (list.contains("nginx")) {
                 task.dependsOn("start${NginxTaskPreparer.extName}")
-            }*/
+            }
         }
 
         project.tasks.register("stopEnv") { task ->
@@ -177,9 +177,9 @@ open class ICMDockerPlugin : Plugin<Project> {
             if (list.contains("oracle")) {
                 task.dependsOn("stop${OracleTaskPreparer.extName}")
             }
-            /* TODO #72088 if (list.contains("nginx")) {
+            if (list.contains("nginx")) {
                 task.dependsOn("stop${NginxTaskPreparer.extName}")
-            }*/
+            }
         }
     }
 

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/ICMDockerPlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/ICMDockerPlugin.kt
@@ -84,7 +84,7 @@ open class ICMDockerPlugin : Plugin<Project> {
             val solrcloudPreparer = SolrCloudPreparer(project, networkTasks)
 
             val webServerTasks = WebServerPreparer(project, networkTasks)
-            val nginxTasks = NginxTaskPreparer(project, networkTasks.createNetworkTask, webServerTasks.waTasks)
+            val nginxTasks = NginxTaskPreparer(project, networkTasks.createNetworkTask)
 
             try {
                 tasks.named("dbPrepare").configure {

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/extension/Images.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/extension/Images.kt
@@ -43,9 +43,7 @@ open class Images @Inject constructor(objectFactory: ObjectFactory) {
 
     val testmailsrv: Property<String> = objectFactory.property(String::class.java)
 
-    /* TODO #72088
     val nginx: Property<String> = objectFactory.property(String::class.java)
-     */
 
     init {
         icmcustomizationbase.convention("intershophub/icm-as-customization-base:latest")
@@ -62,8 +60,6 @@ open class Images @Inject constructor(objectFactory: ObjectFactory) {
 
         testmailsrv.convention("docker-internal.rnd.intershop.de/icm-test/iste-mail:latest")
 
-        /* TODO #72088
         nginx.convention("intershophub/nginx-intershop:1.0.0")
-         */
     }
 }

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/extension/Images.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/extension/Images.kt
@@ -60,6 +60,6 @@ open class Images @Inject constructor(objectFactory: ObjectFactory) {
 
         testmailsrv.convention("docker-internal.rnd.intershop.de/icm-test/iste-mail:latest")
 
-        nginx.convention("intershophub/nginx-intershop:1.0.0")
+        nginx.convention("intershophub/icm-nginx:latest")
     }
 }

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/utils/nginx/TaskPreparer.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/utils/nginx/TaskPreparer.kt
@@ -19,16 +19,16 @@ package com.intershop.gradle.icm.docker.utils.nginx
 import com.intershop.gradle.icm.docker.tasks.PrepareNetwork
 import com.intershop.gradle.icm.docker.tasks.StartExtraContainer
 import com.intershop.gradle.icm.docker.utils.AbstractTaskPreparer
-import com.intershop.gradle.icm.docker.utils.webserver.WATaskPreparer
-import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 import com.intershop.gradle.icm.docker.utils.Configuration
 import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import java.io.File
 
-class TaskPreparer(project: Project,
-                   networkTask: Provider<PrepareNetwork>, waTaskPreparer:WATaskPreparer
-    ) : AbstractTaskPreparer(project, networkTask){
+class TaskPreparer(
+    project: Project,
+    networkTask: Provider<PrepareNetwork>
+) : AbstractTaskPreparer(project, networkTask) {
 
     companion object {
         const val extName: String = "NGINX"
@@ -58,25 +58,33 @@ class TaskPreparer(project: Project,
             task.image.set(pullTask.get().image)
 
             with(dockerExtension.developmentConfig) {
-                val httpPortMapping = getPortMapping("HTTP",
+                val httpPortMapping = getPortMapping(
+                    "HTTP",
                     Configuration.NGINX_HTTP_PORT,
                     Configuration.NGINX_HTTP_PORT_VALUE,
-                        HTTP_CONTAINER_PORT,
+                    HTTP_CONTAINER_PORT,
                     false
                 )
-                val httpsPortMapping = getPortMapping("HTTPS",
-                        Configuration.NGINX_HTTPS_PORT,
-                        Configuration.NGINX_HTTPS_PORT_VALUE,
-                        HTTPS_CONTAINER_PORT,
-                        true
+                val httpsPortMapping = getPortMapping(
+                    "HTTPS",
+                    Configuration.NGINX_HTTPS_PORT,
+                    Configuration.NGINX_HTTPS_PORT_VALUE,
+                    HTTPS_CONTAINER_PORT,
+                    true
                 )
                 task.withPortMappings(httpPortMapping, httpsPortMapping)
                 task.hostConfig.network.set(networkId)
 
                 task.envVars.set(
                     mutableMapOf(
-                        ENV_UPSTREAM_HOST to waTaskPreparer.getContainerName(),
-                        ENV_UPSTREAM_PORT to waTaskPreparer.httpContainerPort.toString(),
+                        ENV_UPSTREAM_HOST to getConfigProperty(
+                            Configuration.LOCAL_CONNECTOR_HOST,
+                            Configuration.LOCAL_CONNECTOR_HOST_VALUE
+                        ),
+                        ENV_UPSTREAM_PORT to getConfigProperty(
+                            Configuration.AS_SERVICE_CONNECTOR_PORT,
+                            Configuration.AS_SERVICE_CONNECTOR_PORT_VALUE.toString()
+                        ),
                         ENV_SSL_CERTIFICATEFILENAME to
                                 getConfigProperty(
                                     Configuration.NGINX_CERT_FILENAME,
@@ -90,22 +98,39 @@ class TaskPreparer(project: Project,
                     )
                 )
 
-                val certPath =  dockerExtension.developmentConfig.getConfigProperty(Configuration.NGINX_CERT_PATH)
-                if (certPath.isBlank()){
-                    throw GradleException("Missing or empty property '${Configuration.NGINX_CERT_PATH}' in your " +
-                                          "icm.properties!")
+                val nginxCertPath = dockerExtension.developmentConfig.getConfigProperty(Configuration.NGINX_CERT_PATH)
+                val wsCertPath = dockerExtension.developmentConfig.getConfigProperty(Configuration.WS_CERT_PATH)
+
+                // if NginxCertPath is not set, we take the webserver certificate path instead
+                val certPath: String
+                val configOption: String
+                if (nginxCertPath.isBlank() && wsCertPath.isBlank()) {
+                    throw GradleException(
+                        "Missing or empty property '${Configuration.NGINX_CERT_PATH}' in your " +
+                                "icm.properties!"
+                    )
+                } else {
+                    certPath = if (nginxCertPath.isNotBlank()) {
+                        configOption = Configuration.NGINX_CERT_PATH
+                        nginxCertPath
+                    } else {
+                        configOption = Configuration.WS_CERT_PATH
+                        wsCertPath
+                    }
                 }
+
                 val certDir = File(certPath)
-                if(!certDir.exists()){
-                    throw GradleException("Property '${Configuration.NGINX_CERT_PATH}' in your icm.properties " +
-                                          "points to a non-existing or non-accessible path!")
+                if (!certDir.exists()) {
+                    throw GradleException(
+                        "Property '${configOption}' in your icm.properties " +
+                                "points to a non-existing or non-accessible path: '${certPath}'"
+                    )
                 }
 
                 task.hostConfig.binds.set(
-                        mutableMapOf(certDir.absolutePath to VOLUME_SSL)
+                    mutableMapOf(certDir.absolutePath to VOLUME_SSL)
                 )
             }
-            task.mustRunAfter(waTaskPreparer.startTask)
             task.dependsOn(pullTask, networkTask)
         }
     }

--- a/src/main/kotlin/com/intershop/gradle/icm/docker/utils/nginx/TaskPreparer.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/docker/utils/nginx/TaskPreparer.kt
@@ -17,13 +17,17 @@
 package com.intershop.gradle.icm.docker.utils.nginx
 
 import com.intershop.gradle.icm.docker.tasks.PrepareNetwork
+import com.intershop.gradle.icm.docker.tasks.StartExtraContainer
 import com.intershop.gradle.icm.docker.utils.AbstractTaskPreparer
 import com.intershop.gradle.icm.docker.utils.webserver.WATaskPreparer
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import com.intershop.gradle.icm.docker.utils.Configuration
+import org.gradle.api.GradleException
+import java.io.File
 
 class TaskPreparer(project: Project,
-                   networkTask: Provider<PrepareNetwork>
+                   networkTask: Provider<PrepareNetwork>, waTaskPreparer:WATaskPreparer
     ) : AbstractTaskPreparer(project, networkTask){
 
     companion object {
@@ -41,7 +45,7 @@ class TaskPreparer(project: Project,
 
     override fun getExtensionName(): String = extName
 
-    override fun getImage(): Provider<String> = project.provider { "TODO" }/* TODO #72088extension.images.nginx
+    override fun getImage(): Provider<String> = dockerExtension.images.nginx
 
     init {
         initBaseTasks()
@@ -53,7 +57,7 @@ class TaskPreparer(project: Project,
             task.targetImageId(project.provider { pullTask.get().image.get() })
             task.image.set(pullTask.get().image)
 
-            with(extension.developmentConfig) {
+            with(dockerExtension.developmentConfig) {
                 val httpPortMapping = getPortMapping("HTTP",
                     Configuration.NGINX_HTTP_PORT,
                     Configuration.NGINX_HTTP_PORT_VALUE,
@@ -86,7 +90,7 @@ class TaskPreparer(project: Project,
                     )
                 )
 
-                val certPath =  extension.developmentConfig.getConfigProperty(Configuration.NGINX_CERT_PATH)
+                val certPath =  dockerExtension.developmentConfig.getConfigProperty(Configuration.NGINX_CERT_PATH)
                 if (certPath.isBlank()){
                     throw GradleException("Missing or empty property '${Configuration.NGINX_CERT_PATH}' in your " +
                                           "icm.properties!")
@@ -98,12 +102,12 @@ class TaskPreparer(project: Project,
                 }
 
                 task.hostConfig.binds.set(
-                        ContainerUtils.transformVolumes(mutableMapOf(certDir.absolutePath to VOLUME_SSL))
+                        mutableMapOf(certDir.absolutePath to VOLUME_SSL)
                 )
             }
             task.mustRunAfter(waTaskPreparer.startTask)
             task.dependsOn(pullTask, networkTask)
         }
     }
-    */
+
 }


### PR DESCRIPTION
This PR adds tasks to start/stop/pull the [icm-nginx](https://hub.docker.com/repository/registry-1.docker.io/intershophub/icm-nginx/general) image which can be used as alternative reverse proxy to the WebAdapter for development.

The PR is based on previous work by @skiesewetter-intershop.