### PR TITLE
chore: remove required sonatype username

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ group = "com.intershop.gradle.icm.docker"
 description = "Intershop Commerce Management Plugins for Docker Integration"
 version = scm.version.version
 
-val sonatypeUsername: String by project
+val sonatypeUsername: String? by project
 val sonatypePassword: String? by project
 
 repositories {


### PR DESCRIPTION
When working on the icm-docker-plugin locally, the required username prevents me from building the plugin locally.