### PR TITLE
feat: consume icm-gradle-plugin:6.2.0 to make cumulative library lists available (#100)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -304,7 +304,7 @@ dependencies {
 
     implementation("org.apache.solr:solr-solrj:9.4.0")
     implementation("com.bmuschko.docker-remote-api:com.bmuschko.docker-remote-api.gradle.plugin:9.3.6")
-    implementation("com.intershop.gradle.icm:icm-gradle-plugin:6.1.0")
+    implementation("com.intershop.gradle.icm:icm-gradle-plugin:6.2.0")
     implementation("com.intershop.gradle.jobrunner:icmjobrunner:2.0.1")
 }
 


### PR DESCRIPTION
Attention: build will fail until icm-gradle-plugin:6.2.0 actually is released